### PR TITLE
Feature/add user instructions

### DIFF
--- a/maze.py
+++ b/maze.py
@@ -498,11 +498,11 @@ if __name__ == "__main__":
    
 #Insturctions for the player to type commands are as follows:
     legend.create_text(110, 410, text="Commands", anchor=NW, font=('Arial', '14', 'underline'))
-    legend.create_text(0, 460, text="Commands are NOT case sensitive:" , anchor=NW, font=('Arial', '12', 'bold'))
-    legend.create_text(0, 500, text="To Move in the direction you are facing,\nuse 'MOVE 'x' where 'x' is the number \nof spaces to move", anchor=NW, font=('Arial', '12')) 
-    legend.create_text(0, 570, text="To Turn Left 90" + u'\u00B0' + ", use 'TURN LEFT'", anchor=NW, font=('Arial', '12'))
-    legend.create_text(0, 600, text="To Turn Right 90" + u'\u00B0' + ", use 'TURN RIGHT'", anchor=NW, font=('Arial', '12'))
-    legend.create_text(0, 630, text="To Fire the Laser, use 'FIRE'", anchor=NW, font=('Arial', '12'))
+    legend.create_text(0, 450, text="Commands are NOT case sensitive:" , anchor=NW, font=('Arial', '12', 'bold'))
+    legend.create_text(0, 490, text="To Move in the direction you are facing,\nuse 'MOVE 'x' where 'x' is the number \nof spaces to move", anchor=NW, font=('Arial', '12')) 
+    legend.create_text(0, 560, text="To Turn Left 90" + u'\u00B0' + ", use 'TURN LEFT'", anchor=NW, font=('Arial', '12'))
+    legend.create_text(0, 590, text="To Turn Right 90" + u'\u00B0' + ", use 'TURN RIGHT'", anchor=NW, font=('Arial', '12'))
+    legend.create_text(0, 620, text="To Fire the Laser, use 'FIRE'", anchor=NW, font=('Arial', '12'))
 
     # GAME CANVAS
     canvas = Canvas(root)


### PR DESCRIPTION
As can be seen in the changelog, I've added lines to show instructions to the player in the bottom right hand corner of the game window. The final line is 630 pixels from the top of the canvas which only extends down to 650, so any further additions would require extending this. I have also underlined the titles for 'Maze Legend' and 'Commands'